### PR TITLE
[DEVEM-524] Set explicit version range for slf4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Alfresco remote testrunner - Changelog
 
+## 2.0.1 (2023-01-04)
+
+* [#4](https://github.com/xenit-eu/alfresco-remote-testrunner/pull/4) [DEVEM-524](https://xenitsupport.jira.com/browse/DEVEM-524) Modify osgi manifest generation to allow for systems that only provide org.slf4j. > 2.0.0
+
 ## 2.0.0 (2021-08-10)
 
 No changes from previous version.

--- a/alfresco-remote-testrunner/build.gradle
+++ b/alfresco-remote-testrunner/build.gradle
@@ -64,7 +64,7 @@ jar {
             'Bundle-SymbolicName': "${project.group}.${project.name}",
             'Bundle-Version': "${project.version.version.normal}",
             'Alfresco-Spring-Configuration': 'eu.xenit.testing.integrationtesting',
-            'Import-Package': 'org.alfresco.*,org.springframework.*;version=\"[3.0,999)\",com.github.dynamicextensionsalfresco.*,org.osgi.*,org.slf4j.*',
+            'Import-Package': 'org.alfresco.*,org.springframework.*;version=\"[3.0,999)\",com.github.dynamicextensionsalfresco.*,org.osgi.*,org.slf4j.*;version=\"[1.7.2, 999)\"',
             'Export-Package': 'junit.framework;version=4.12,'
                     + 'org.junit;version=4.12,'
                     + 'org.junit.runner;version=4.12,'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "base"
     id 'eu.xenit.de' version '2.0.5' apply false
     id 'eu.xenit.alfresco' version '1.0.1'
-    id 'org.ajoberstar.reckon' version '0.13.0'
+    id 'org.ajoberstar.reckon' version '0.13.2'
     id 'com.github.hierynomus.license' version '0.15.0'
     id "org.sonarqube" version "3.2.0"
 }


### PR DESCRIPTION
On the latest alfresco version (7.3) the slf4j version is updated to 2.x.
    Functionally, this is backwards compatible with the version used in the code here.
    Although, because no explicit version was set, bnd/osgi infers a version range automatically,
    resulting in (1.7.6, 2.0.0). This will cause failure to install on systems
    providing higher versions (eg alf7.3).
    By setting the version explicitly, we hope to avoid this issue.